### PR TITLE
Fix authority management for metadata build with item enhancer

### DIFF
--- a/dspace-api/src/main/java/org/dspace/content/authority/MetadataAuthorityManager.java
+++ b/dspace-api/src/main/java/org/dspace/content/authority/MetadataAuthorityManager.java
@@ -13,7 +13,6 @@ import java.util.Map;
 import java.util.HashMap;
 import java.util.Enumeration;
 
-
 import org.apache.log4j.Logger;
 
 import org.dspace.content.MetadataField;
@@ -21,43 +20,42 @@ import org.dspace.core.ConfigurationManager;
 
 /**
  * Broker for metadata authority settings configured for each metadata field.
- *
+ * 
  * Configuration keys, per metadata field (e.g. "dc.contributer.author")
- *
- *  # is field authority controlled (i.e. store authority, confidence values)?
- *  authority.controlled.<FIELD> = true
- *
- *  # is field required to have an authority value, or may it be empty?
- *  # default is false.
- *  authority.required.<FIELD> = true | false
- *
- *  # default value of minimum confidence level for ALL fields - must be
- *  # symbolic confidence level, see org.dspace.content.authority.Choices
- *  authority.minconfidence = uncertain
- *
- *  # minimum confidence level for this field
- *  authority.minconfidence.SCHEMA.ELEMENT.QUALIFIER = SYMBOL
- *    e.g.
- *  authority.minconfidence.dc.contributor.author = accepted
- *
+ * 
+ * # is field authority controlled (i.e. store authority, confidence values)?
+ * authority.controlled.<FIELD> = true
+ * 
+ * # is field required to have an authority value, or may it be empty? # default
+ * is false. authority.required.<FIELD> = true | false
+ * 
+ * # default value of minimum confidence level for ALL fields - must be #
+ * symbolic confidence level, see org.dspace.content.authority.Choices
+ * authority.minconfidence = uncertain
+ * 
+ * # minimum confidence level for this field
+ * authority.minconfidence.SCHEMA.ELEMENT.QUALIFIER = SYMBOL e.g.
+ * authority.minconfidence.dc.contributor.author = accepted
+ * 
  * NOTE: There is *expected* to be a "choices" (see ChoiceAuthorityManager)
  * configuration for each authority-controlled field.
- *
+ * 
  * @see ChoiceAuthorityManager
  * @see Choices
  * @author Larry Stone
  */
 public class MetadataAuthorityManager
 {
-    private static Logger log = Logger.getLogger(MetadataAuthorityManager.class);
+    private static Logger log = Logger
+            .getLogger(MetadataAuthorityManager.class);
 
     private static MetadataAuthorityManager cached = null;
 
     // map of field key to authority plugin
-    private Map<String,Boolean> controlled = new HashMap<String,Boolean>();
+    private Map<String, Boolean> controlled = new HashMap<String, Boolean>();
 
     // map of field key to answer of whether field is required to be controlled
-    private Map<String,Boolean> isAuthorityRequired = new HashMap<String,Boolean>();
+    private Map<String, Boolean> isAuthorityRequired = new HashMap<String, Boolean>();
 
     /**
      * map of field key to answer of which is the min acceptable confidence
@@ -73,10 +71,9 @@ public class MetadataAuthorityManager
 
         Enumeration pn = ConfigurationManager.propertyNames();
         final String authPrefix = "authority.controlled.";
-      property:
-        while (pn.hasMoreElements())
+        property: while (pn.hasMoreElements())
         {
-            String key = (String)pn.nextElement();
+            String key = (String) pn.nextElement();
             if (key.startsWith(authPrefix))
             {
                 // field is expected to be "schema.element.qualifier"
@@ -84,32 +81,37 @@ public class MetadataAuthorityManager
                 int dot = field.indexOf('.');
                 if (dot < 0)
                 {
-                    log.warn("Skipping invalid MetadataAuthority configuration property: "+key+": does not have schema.element.qualifier");
+                    log.warn("Skipping invalid MetadataAuthority configuration property: "
+                            + key + ": does not have schema.element.qualifier");
                     continue property;
                 }
                 String schema = field.substring(0, dot);
-                String element = field.substring(dot+1);
+                String element = field.substring(dot + 1);
                 String qualifier = null;
                 dot = element.indexOf('.');
                 if (dot >= 0)
                 {
-                    qualifier = element.substring(dot+1);
+                    qualifier = element.substring(dot + 1);
                     element = element.substring(0, dot);
                 }
 
                 String fkey = makeFieldKey(schema, element, qualifier);
-                boolean ctl = ConfigurationManager.getBooleanProperty(key, true);
-                boolean req = ConfigurationManager.getBooleanProperty("authority.required."+field, false);
+                boolean ctl = ConfigurationManager
+                        .getBooleanProperty(key, true);
+                boolean req = ConfigurationManager.getBooleanProperty(
+                        "authority.required." + field, false);
                 controlled.put(fkey, Boolean.valueOf(ctl));
                 isAuthorityRequired.put(fkey, Boolean.valueOf(req));
 
                 // get minConfidence level for this field if any
-                int mci = readConfidence("authority.minconfidence."+field);
+                int mci = readConfidence("authority.minconfidence." + field);
                 if (mci >= Choices.CF_UNSET)
                 {
                     minConfidence.put(fkey, Integer.valueOf(mci));
                 }
-                log.debug("Authority Control: For schema="+schema+", elt="+element+", qual="+qualifier+", controlled="+ctl+", required="+req);
+                log.debug("Authority Control: For schema=" + schema + ", elt="
+                        + element + ", qual=" + qualifier + ", controlled="
+                        + ctl + ", required=" + req);
             }
         }
 
@@ -126,17 +128,20 @@ public class MetadataAuthorityManager
         String mc = ConfigurationManager.getProperty(key);
         if (mc != null)
         {
-            int mci = Choices.getConfidenceValue(mc.trim(), Choices.CF_UNSET-1);
-            if (mci == Choices.CF_UNSET-1)
-                {
-                log.warn("IGNORING bad value in DSpace Configuration, key="+key+", value="+mc+", must be a valid Authority Confidence keyword.");
-                }
+            int mci = Choices.getConfidenceValue(mc.trim(),
+                    Choices.CF_UNSET - 1);
+            if (mci == Choices.CF_UNSET - 1)
+            {
+                log.warn("IGNORING bad value in DSpace Configuration, key="
+                        + key + ", value=" + mc
+                        + ", must be a valid Authority Confidence keyword.");
+            }
             else
             {
                 return mci;
             }
         }
-        return Choices.CF_UNSET-1;
+        return Choices.CF_UNSET - 1;
     }
 
     // factory method
@@ -149,9 +154,9 @@ public class MetadataAuthorityManager
         return cached;
     }
 
-
     /** Predicate - is field authority-controlled? */
-    public boolean isAuthorityControlled(String schema, String element, String qualifier)
+    public boolean isAuthorityControlled(String schema, String element,
+            String qualifier)
     {
         return isAuthorityControlled(makeFieldKey(schema, element, qualifier));
     }
@@ -159,12 +164,13 @@ public class MetadataAuthorityManager
     /** Predicate - is field authority-controlled? */
     public boolean isAuthorityControlled(String fieldKey)
     {
-        return controlled.containsKey(fieldKey) && controlled.get(fieldKey).booleanValue();
+        return controlled.containsKey(fieldKey)
+                && controlled.get(fieldKey).booleanValue();
     }
 
-
     /** Predicate - is authority value required for field? */
-    public boolean isAuthorityRequired(String schema, String element, String qualifier)
+    public boolean isAuthorityRequired(String schema, String element,
+            String qualifier)
     {
         return isAuthorityRequired(makeFieldKey(schema, element, qualifier));
     }
@@ -177,37 +183,41 @@ public class MetadataAuthorityManager
     }
 
     /**
-     * Construct a single key from the tuple of schema/element/qualifier
-     * that describes a metadata field.  Punt to the function we use for
-     * submission UI input forms, for now.
+     * Construct a single key from the tuple of schema/element/qualifier that
+     * describes a metadata field. Punt to the function we use for submission UI
+     * input forms, for now.
      */
-    public static String makeFieldKey(String schema, String element, String qualifier)
+    public static String makeFieldKey(String schema, String element,
+            String qualifier)
     {
         return MetadataField.formKey(schema, element, qualifier);
     }
 
     /**
-     * Give the minimal level of confidence required to consider valid an authority value
-     * for the given metadata.
+     * Give the minimal level of confidence required to consider valid an
+     * authority value for the given metadata.
+     * 
      * @return the minimal valid level of confidence for the given metadata
      */
     public int getMinConfidence(String schema, String element, String qualifier)
     {
-        Integer result = minConfidence.get(makeFieldKey(schema, element, qualifier));
+        Integer result = minConfidence.get(makeFieldKey(schema, element,
+                qualifier));
         return result == null ? defaultMinConfidence : result.intValue();
     }
 
     /**
-     * Return the list of metadata field with authority control. The strings
-     * are in the form <code>schema.element[.qualifier]</code>
-     *
+     * Return the list of metadata field with authority control. The strings are
+     * in the form <code>schema.element[.qualifier]</code>
+     * 
      * @return the list of metadata field with authority control
      */
-    public List<String> getAuthorityMetadata() {
+    public List<String> getAuthorityMetadata()
+    {
         List<String> copy = new ArrayList<String>();
         for (String s : controlled.keySet())
         {
-            copy.add(s.replaceAll("_","."));
+            copy.add(s.replaceAll("_", "."));
         }
         return copy;
     }

--- a/dspace-jspui/dspace-jspui-api/src/main/java/org/dspace/app/webui/servlet/admin/AuthorityManagementServlet.java
+++ b/dspace-jspui/dspace-jspui-api/src/main/java/org/dspace/app/webui/servlet/admin/AuthorityManagementServlet.java
@@ -33,6 +33,7 @@ import org.dspace.content.authority.AuthorityInfo;
 import org.dspace.content.authority.ChoiceAuthorityManager;
 import org.dspace.content.authority.Choices;
 import org.dspace.content.authority.MetadataAuthorityManager;
+import org.dspace.core.ConfigurationManager;
 import org.dspace.core.Context;
 import org.dspace.core.I18nUtil;
 import org.dspace.core.LogManager;
@@ -276,8 +277,16 @@ public class AuthorityManagementServlet extends DSpaceServlet
         if (detail)
         {
             MetadataAuthorityManager mam = MetadataAuthorityManager.getManager();
-            List<String> authorityMetadata = mam.getAuthorityMetadata();
-            
+            List<String> authorityMetadata = new ArrayList<String>();
+            List<String> tmpAuthorityMetadata = mam.getAuthorityMetadata();
+            final String authManagementPrefix = "authority.management.";
+            for(String tmp : tmpAuthorityMetadata) {
+                boolean req = ConfigurationManager.getBooleanProperty(
+                        authManagementPrefix + tmp, true);
+                if(req) {
+                    authorityMetadata.add(tmp);
+                }
+            }
             Collections.sort(authorityMetadata, configurationKeyComparator);
             
             request.setAttribute("authorities", authorityMetadata);

--- a/dspace/config/dspace.cfg
+++ b/dspace/config/dspace.cfg
@@ -1787,9 +1787,10 @@ authority.controlled.dc.description.sponsorship = true
 
 choices.plugin.dc.relation.ispartof = JOURNALAuthority
 choices.presentation.dc.relation.ispartof = suggest
-authority.controlled.dc.relation.ispartof = false
+authority.controlled.dc.relation.ispartof = true
 cris.DOAuthority.dc_relation_ispartof.filter = resourcetype_filter:"Journals"
 
 ## It comes from ItemEnhancer configuration - see cris-metadata.enhancers.xml
 choices.plugin.crisitem.author.dept = OUAuthority
 authority.controlled.crisitem.author.dept = true
+authority.management.crisitem.author.dept = false


### PR DESCRIPTION
- Added sanity check to make sure that ChoiceAuthorityManager work with a real field
- Added configuration authority.management.crisitem.author.dept to control metadata to showed for AuthorityManagementServlet
- Reformat code for MetadataAuthorityManager
