### PR TITLE
Update SolrImportExport.java to ad value to search.uniqueid

### DIFF
--- a/dspace-api/src/main/java/org/dspace/util/SolrImportExport.java
+++ b/dspace-api/src/main/java/org/dspace/util/SolrImportExport.java
@@ -183,7 +183,7 @@ public class SolrImportExport
 
 	private static Options makeOptions() {
 		Options options = new Options();
-		options.addOption(ACTION_OPTION, "action", true, "The action to perform: import, export or reindex. Default: export.");
+		options.addOption(ACTION_OPTION, "action", true, "The action to perform: import, export, generate or reindex. Default: export.");
 		options.addOption(CLEAR_OPTION, "clear", false, "When importing, also clear the index first. Ignored when action is export or reindex.");
 		options.addOption(DIRECTORY_OPTION, "directory", true,
 				                 "The absolute path for the directory to use for import or export. If omitted, [dspace]/solr-export is used.");


### PR DESCRIPTION
In the DSpace-Cris there is a new search.uniqueid data that has to be valued as 
 search.uniqueid = type + "-" + id 
In case of migration from standard DSpace installation this data has to be generated
Add a new option "generate" to perform this type of automatic update.
