### PR TITLE
incorrect location of useProxies option

### DIFF
--- a/dspace-api/src/main/java/org/dspace/statistics/SolrLogger.java
+++ b/dspace-api/src/main/java/org/dspace/statistics/SolrLogger.java
@@ -105,8 +105,7 @@ public class SolrLogger
         if (useProxies == null)
         {
             boolean result = false;
-            if ("true".equals(ConfigurationManager.getProperty(CFG_STAT_MODULE,
-                    "useProxies")))
+            if ("true".equals(ConfigurationManager.getProperty("useProxies")))
             {
                 result = true;
             }


### PR DESCRIPTION
the useProxies option is usually declared in dspace.cfg not in solr-statistics.cfg
